### PR TITLE
Andreasn/datebugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helsenorge/refero",
-  "version": "10.0.1",
+  "version": "10.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@helsenorge/refero",
-      "version": "10.0.1",
+      "version": "10.1.3",
       "license": "MIT",
       "dependencies": {
         "@types/react-collapse": "5.0.0",

--- a/src/components/formcomponents/date/date.tsx
+++ b/src/components/formcomponents/date/date.tsx
@@ -94,9 +94,9 @@ class DateComponent extends React.Component<Props & ValidationProps> {
   getYear() {
     const { item, answer } = this.props;
     if (answer && answer.valueDate) {
-      return new Date(Number(answer.valueDate), 1);
+      return new Date(answer.valueDate.toString() + 'T11:11');
     } else if (item.initial && item.initial[0].valueDate) {
-      return new Date(Number(item.initial[0].valueDate), 1);
+      return new Date(item.initial[0].valueDate.toString() + 'T11:11');
     } else {
       return undefined;
     }

--- a/src/components/formcomponents/date/date.tsx
+++ b/src/components/formcomponents/date/date.tsx
@@ -91,6 +91,17 @@ class DateComponent extends React.Component<Props & ValidationProps> {
     return parseDate(String(item.initial[0].valueDateTime));
   }
 
+  getYear() {
+    const { item, answer } = this.props;
+    if (answer && answer.valueDate) {
+      return new Date(Number(answer.valueDate), 1);
+    } else if (item.initial && item.initial[0].valueDate) {
+      return new Date(Number(item.initial[0].valueDate), 1);
+    } else {
+      return undefined;
+    }
+  }
+
   getMaxDate(): Moment | undefined {
     const maxDate = getExtension(ExtensionConstants.DATE_MAX_VALUE_URL, this.props.item);
     if (maxDate && maxDate.valueString) {
@@ -168,6 +179,7 @@ class DateComponent extends React.Component<Props & ValidationProps> {
 
   render(): JSX.Element | null {
     const date = this.getValue();
+    const year = this.getYear();
     const subLabelText = getSublabelText(this.props.item, this.props.onRenderMarkdown, this.props.questionnaire, this.props.resources);
 
     const itemControls = getItemControlExtensionValue(this.props.item);
@@ -195,7 +207,7 @@ class DateComponent extends React.Component<Props & ValidationProps> {
           helpElement={this.props.renderHelpElement()}
           onDateValueChange={this.onDateValueChange}
           className={this.props.className}
-          yearValue={date ? date.getFullYear() : undefined}
+          yearValue={year ? year.getFullYear() : undefined}
           maxDate={this.getMaxDate()}
           minDate={this.getMinDate()}
           {...this.props}


### PR DESCRIPTION
Fixed bug that defaulted to year 2001 in date-year-input and made it impossible to use backspace to remove the numbers in the field. 

What caused the bug?: The bug was caused by trying to create a date in the same way as the other year-fields. This wasn't possible in the date-year-input field. By trying to create a date with just one number (year) and no other parameters, the date became undefined, and Chrome handles undefined dates by returning a random date with the year 2001. In Firefox the application crashed.

How was the bug fixed: I created a separated function to get the year value. In this function I created the date objects correctly by using new Date() with two parameters: the year input, and a time over 00:00.