### PR TITLE
Skjemautfyller: Kopiere eller flytte datafelter til en oppsummeringsfunksjon (pri 4)

### DIFF
--- a/src/components/__tests__/componentsWithChildren-spec.tsx
+++ b/src/components/__tests__/componentsWithChildren-spec.tsx
@@ -7,7 +7,7 @@ import '../../util/defineFetch';
 import rootReducer from '../../reducers';
 import { ReferoContainer } from '../../components';
 import { Resources } from '../../util/resources';
-import { Questionnaire, QuestionnaireItem, Extension, Coding } from '../../types/fhir';
+import { Questionnaire, QuestionnaireItem, Extension } from '../../types/fhir';
 import Choice from '../formcomponents/choice/choice';
 import Boolean from '../formcomponents/boolean/boolean';
 import Decimal from '../formcomponents/decimal/decimal';
@@ -21,6 +21,7 @@ import OpenChoice from '../formcomponents/open-choice/open-choice';
 import Attachment from '../formcomponents/attachment/attachment';
 import Quantity from '../formcomponents/quantity/quantity';
 import Valueset from '../../util/__tests__/__data__/valuesets/valueset-8459';
+import { createItemControlExtension } from '../__tests__/utils';
 
 describe('Components render children', () => {
   beforeEach(() => {
@@ -179,22 +180,6 @@ describe('Components render children', () => {
     expect(wrapper.find(OpenChoice)).toHaveLength(3);
   });
 });
-
-function createItemControlExtension(code: string): Extension {
-  return {
-    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
-    valueCodeableConcept: {
-      coding: [createItemControlCoding(code)],
-    },
-  } as Extension;
-}
-
-function createItemControlCoding(code: string): Coding {
-  return {
-    code: code,
-    system: 'http://hl7.org/fhir/ValueSet/questionnaire-item-control',
-  } as Coding;
-}
 
 function creatNestedItem(type: string, ...withExtensions: Extension[]): QuestionnaireItem {
   return createItem(

--- a/src/components/__tests__/group-spec.tsx
+++ b/src/components/__tests__/group-spec.tsx
@@ -10,11 +10,11 @@ import { QuestionnaireItem, QuestionnaireResponseItemAnswer, Extension, Question
 import { Path } from '../../util/refero-core';
 import { Group } from '../formcomponents/group/group';
 import StringComponent from '../../components/formcomponents/string/string';
-import Extensions from '../../constants/extensions';
 import { GlobalState } from '../../reducers/index';
 import { NewValueAction } from '../../actions/newValue';
 import { RenderContextType } from '../../constants/renderContextType';
 import { RenderContext } from '../../util/renderContext';
+import { createItemControlExtension } from '../__tests__/utils';
 
 describe('Group component renders with correct classes', () => {
   const defaultClasses = ['.page_refero__component', '.page_refero__component_group'];
@@ -80,20 +80,6 @@ function expectToFindClasses(wrapper: ReactWrapper<{}, {}>, ...classes: string[]
   for (const c of classes) {
     expect(wrapper.find(c)).toHaveLength(1);
   }
-}
-
-function createItemControlExtension(code: string): Extension {
-  return {
-    url: Extensions.ITEMCONTROL_URL,
-    valueCodeableConcept: {
-      coding: [
-        {
-          system: 'http://hl7.org/fhir/ValueSet/questionnaire-item-control',
-          code: code,
-        },
-      ],
-    },
-  } as Extension;
 }
 
 function createWrapperForGroupItem(item: QuestionnaireItem): ReactWrapper<{}, {}> {

--- a/src/components/__tests__/help-spec.tsx
+++ b/src/components/__tests__/help-spec.tsx
@@ -6,7 +6,7 @@ import { ReactWrapper, mount } from 'enzyme';
 
 import '../../util/defineFetch';
 import rootReducer from '../../reducers';
-import { QuestionnaireItem, Extension, Coding, QuestionnaireResponseItemAnswer, QuestionnaireItemAnswerOption } from '../../types/fhir';
+import { QuestionnaireItem, Extension, QuestionnaireResponseItemAnswer, QuestionnaireItemAnswerOption } from '../../types/fhir';
 import { Path } from '../../util/refero-core';
 import String from '../formcomponents/string/string';
 import Choice from '../formcomponents/choice/choice';
@@ -25,6 +25,7 @@ import { GlobalState } from '../../reducers/index';
 import { NewValueAction } from '../../actions/newValue';
 import { RenderContextType } from '../../constants/renderContextType';
 import { RenderContext } from '../../util/renderContext';
+import { createItemControlExtension } from '../__tests__/utils';
 
 describe('Component renders help items', () => {
   beforeEach(() => {
@@ -152,22 +153,6 @@ function createItem(itemType: string, extensions?: Extension[]): QuestionnaireIt
     text: 'item av type ' + itemType,
     extension: extensions,
   };
-}
-
-function createItemControlExtension(code: string): Extension {
-  return {
-    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
-    valueCodeableConcept: {
-      coding: [createItemControlCoding(code)],
-    },
-  } as Extension;
-}
-
-function createItemControlCoding(code: string): Coding {
-  return {
-    code: code,
-    system: 'http://hl7.org/fhir/ValueSet/questionnaire-item-control',
-  } as Coding;
 }
 
 function createWrapperWithComponent(component: JSX.Element): ReactWrapper<{}, {}> {

--- a/src/components/__tests__/hidden-spec.tsx
+++ b/src/components/__tests__/hidden-spec.tsx
@@ -7,7 +7,7 @@ import rootReducer from '../../reducers';
 import '../../util/defineFetch';
 import { Resources } from '../../util/resources';
 import { ReferoContainer } from '../../components';
-import { Questionnaire, QuestionnaireItem, Extension, Coding, Reference } from '../../types/fhir';
+import { Questionnaire, QuestionnaireItem, Extension, Reference } from '../../types/fhir';
 import Choice from '../formcomponents/choice/choice';
 import Boolean from '../formcomponents/boolean/boolean';
 import Decimal from '../formcomponents/decimal/decimal';
@@ -21,6 +21,7 @@ import OpenChoice from '../formcomponents/open-choice/open-choice';
 import Attachment from '../formcomponents/attachment/attachment';
 import Quantity from '../formcomponents/quantity/quantity';
 import Valueset from '../../util/__tests__/__data__/valuesets/valueset-8459';
+import { createItemControlExtension } from '../__tests__/utils';
 
 describe('Hidden components should not render', () => {
   beforeEach(() => {
@@ -335,22 +336,6 @@ function createQuestionnaireHiddenExtension(value: boolean): Extension {
     url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden',
     valueBoolean: value,
   } as Extension;
-}
-
-function createItemControlExtension(code: string): Extension {
-  return {
-    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
-    valueCodeableConcept: {
-      coding: [createItemControlCoding(code)],
-    },
-  } as Extension;
-}
-
-function createItemControlCoding(code: string): Coding {
-  return {
-    code: code,
-    system: 'http://hl7.org/fhir/ValueSet/questionnaire-item-control',
-  } as Coding;
 }
 
 function createItem(type: string, ...withExtensions: Extension[]): QuestionnaireItem {

--- a/src/components/__tests__/index-spec.tsx
+++ b/src/components/__tests__/index-spec.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
-import { Questionnaire, QuestionnaireItem, Extension, QuestionnaireItemEnableWhen } from '../../types/fhir';
+import { Questionnaire, QuestionnaireItem, QuestionnaireItemEnableWhen } from '../../types/fhir';
 
 import SafeInputField from '@helsenorge/form/components/safe-input-field';
 
@@ -18,6 +18,8 @@ import { Resources } from '../../util/resources';
 import HelpButton from '../help-button/help-button';
 import { ReferoContainer } from '../index';
 import RenderingOptionsData from './__data__/renderingOptions';
+import { createItemControlExtension } from '../__tests__/utils';
+import itemcontrol from '../../constants/itemcontrol';
 
 describe('Component renders help items', () => {
   beforeEach(() => {
@@ -205,24 +207,10 @@ function questionnaireWithHelp(): Questionnaire {
             linkId: '1.1',
             type: 'text',
             text: 'help text',
-            extension: [helpExtension()],
+            extension: [createItemControlExtension(itemcontrol.HELP)],
           },
         ],
       } as QuestionnaireItem,
     ],
   };
-}
-
-function helpExtension(): Extension {
-  return {
-    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
-    valueCodeableConcept: {
-      coding: [
-        {
-          system: 'http://hl7.org/fhir/ValueSet/questionnaire-item-control',
-          code: 'help',
-        },
-      ],
-    },
-  } as Extension;
 }

--- a/src/components/__tests__/utils.ts
+++ b/src/components/__tests__/utils.ts
@@ -1,6 +1,6 @@
 import { act } from 'react-dom/test-utils';
 import { ReactWrapper } from 'enzyme';
-import { QuestionnaireItem } from '../../types/fhir';
+import { QuestionnaireItem, Extension, Coding } from '../../types/fhir';
 
 export async function inputAnswer(linkId: string, answer: number | string, wrapper: ReactWrapper<{}, {}>) {
   const id = 'item_' + linkId;
@@ -99,4 +99,20 @@ export function submit(name: string, wrapper: ReactWrapper<{}, {}>) {
   let submit = wrapper.findWhere(it => it.text() === name).find('button');
   submit.simulate('click');
   wrapper.update();
+}
+
+export function createItemControlExtension(code: string): Extension {
+  return {
+    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+    valueCodeableConcept: {
+      coding: [createItemControlCoding(code)],
+    },
+  } as Extension;
+}
+
+function createItemControlCoding(code: string): Coding {
+  return {
+    code: code,
+    system: 'http://hl7.org/fhir/ValueSet/questionnaire-item-control',
+  } as Coding;
 }

--- a/src/components/with-common-functions.tsx
+++ b/src/components/with-common-functions.tsx
@@ -31,7 +31,7 @@ import itemControlConstants from '../constants/itemcontrol';
 import itemType from '../constants/itemType';
 import { GlobalState } from '../reducers';
 import { findHelpItem, isHelpItem, getHelpItemType } from '../util/help';
-import { getComponentForItem, getChildHeaderTag, shouldRenderRepeatButton, getText, isHiddenItem } from '../util/index';
+import { getComponentForItem, getChildHeaderTag, shouldRenderRepeatButton, getText, isHiddenItem, getCopyValue } from '../util/index';
 import {
   Path,
   getAnswerFromResponseItem,
@@ -273,8 +273,8 @@ export default function withCommonFunctions<T>(WrappedComponent: React.Component
         }
       }
       const renderedItems: Array<JSX.Element | undefined> = [];
-
       if (response && response.length > 0) {
+        response = getCopyValue(item, this.props.responseItem) ?? response;
         response.forEach((responseItem, index) => {
           renderedItems.push(
             <Comp

--- a/src/components/with-common-functions.tsx
+++ b/src/components/with-common-functions.tsx
@@ -31,7 +31,7 @@ import itemControlConstants from '../constants/itemcontrol';
 import itemType from '../constants/itemType';
 import { GlobalState } from '../reducers';
 import { findHelpItem, isHelpItem, getHelpItemType } from '../util/help';
-import { getComponentForItem, getChildHeaderTag, shouldRenderRepeatButton, getText, isHiddenItem, getCopyValue } from '../util/index';
+import { getComponentForItem, getChildHeaderTag, shouldRenderRepeatButton, getText, isHiddenItem } from '../util/index';
 import {
   Path,
   getAnswerFromResponseItem,
@@ -274,7 +274,6 @@ export default function withCommonFunctions<T>(WrappedComponent: React.Component
       }
       const renderedItems: Array<JSX.Element | undefined> = [];
       if (response && response.length > 0) {
-        response = getCopyValue(item, this.props.responseItem) ?? response;
         response.forEach((responseItem, index) => {
           renderedItems.push(
             <Comp

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -17,6 +17,7 @@ export default {
   REPEATSTEXT_URL: 'http://ehelse.no/fhir/StructureDefinition/repeatstext',
   OPTION_REFERENCE: 'http://ehelse.no/fhir/StructureDefinition/sdf-optionReference',
   CALCULATED_EXPRESSION: 'http://ehelse.no/fhir/StructureDefinition/sdf-calculatedExpression',
+  Copy_EXPRESSION: 'http://hl7.org/fhir/StructureDefinition/cqf-expression',
   DATE_MAX_VALUE_URL: 'http://ehelse.no/fhir/StructureDefinition/sdf-maxvalue',
   DATE_MIN_VALUE_URL: 'http://ehelse.no/fhir/StructureDefinition/sdf-minvalue',
 

--- a/src/constants/itemcontrol.ts
+++ b/src/constants/itemcontrol.ts
@@ -11,6 +11,7 @@ export default {
   YEAR: 'year',
   YEARMONTH: 'yearMonth',
   RECEIVERCOMPONENT: 'receiver-component',
+  DATARECEIVER: 'data-receiver',
   Group: {
     VERTICAL_TABLE: 'table',
     HORIZONTAL_TABLE: 'htable',

--- a/src/util/__tests__/extension-spec.ts
+++ b/src/util/__tests__/extension-spec.ts
@@ -1,4 +1,5 @@
 import extensionConstants from '../../constants/extensions';
+import itemcontrol from '../../constants/itemcontrol';
 import { QuestionnaireItem, Extension } from '../../types/fhir';
 import {
   getValidationTextExtension,
@@ -11,7 +12,10 @@ import {
   getMinLengthExtensionValue,
   getRepeatsTextExtension,
   getRegexExtension,
+  getLinkIdFromCopyExpression,
+  isDataReceiver,
 } from '../extension';
+import { createItemControlExtension } from '../../components/__tests__/utils';
 
 describe('extensions', () => {
   describe('getValidationTextExtension', () => {
@@ -167,5 +171,55 @@ describe('extensions', () => {
       };
       expect(getRegexExtension(item)).toMatchSnapshot();
     });
+  });
+});
+
+describe('isDataReceiver', () => {
+  it('ItemControl is Datareceiver, should return true', () => {
+    const extension = createItemControlExtension(itemcontrol.DATARECEIVER);
+    const item: QuestionnaireItem = {
+      linkId: '2.1',
+      type: 'string',
+      extension: [extension],
+    };
+
+    expect(isDataReceiver(item)).toBeTruthy();
+  });
+
+  it('ItemControl is help, should return false', () => {
+    const extension = createItemControlExtension(itemcontrol.HELP);
+    const item: QuestionnaireItem = {
+      linkId: '2.1',
+      type: 'string',
+      extension: [extension],
+    };
+
+    expect(isDataReceiver(item)).toBeFalsy();
+  });
+});
+
+describe('getLinkIdFromCopyExpression', () => {
+  const testData = [
+    { input: 'valueInteger', itemType: 'integer' },
+    { input: 'value', itemType: 'quantity' },
+    { input: 'valueDecimal', itemType: 'decimal' },
+    { input: 'valueDateTime', itemType: 'date' },
+    { input: 'valueTime', itemType: 'time' },
+    { input: 'valueString', itemType: 'text' },
+    { input: 'valueString', itemType: 'string' },
+    { input: 'choice', itemType: 'valueCoding.system' },
+  ];
+
+  test.each(testData)('Questionnaire ItemType is %s', data => {
+    const extension = {
+      url: extensionConstants.Copy_EXPRESSION,
+      valueString: `QuestionnaireResponse.descendants().where(linkId='24655ca8-7802-47d2-80a0-faa5bd6d0645').answer.value.${data.input}}`,
+    };
+    const item: QuestionnaireItem = {
+      linkId: '2.1',
+      type: data.itemType,
+      extension: [extension],
+    };
+    expect(getLinkIdFromCopyExpression(item)).toBe('24655ca8-7802-47d2-80a0-faa5bd6d0645');
   });
 });

--- a/src/util/__tests__/extension-spec.ts
+++ b/src/util/__tests__/extension-spec.ts
@@ -1,5 +1,4 @@
 import extensionConstants from '../../constants/extensions';
-import itemcontrol from '../../constants/itemcontrol';
 import { QuestionnaireItem, Extension } from '../../types/fhir';
 import {
   getValidationTextExtension,
@@ -12,10 +11,8 @@ import {
   getMinLengthExtensionValue,
   getRepeatsTextExtension,
   getRegexExtension,
-  getLinkIdFromCopyExpression,
-  isDataReceiver,
+  getCopyExtension,
 } from '../extension';
-import { createItemControlExtension } from '../../components/__tests__/utils';
 
 describe('extensions', () => {
   describe('getValidationTextExtension', () => {
@@ -172,54 +169,19 @@ describe('extensions', () => {
       expect(getRegexExtension(item)).toMatchSnapshot();
     });
   });
-});
 
-describe('isDataReceiver', () => {
-  it('ItemControl is Datareceiver, should return true', () => {
-    const extension = createItemControlExtension(itemcontrol.DATARECEIVER);
-    const item: QuestionnaireItem = {
-      linkId: '2.1',
-      type: 'string',
-      extension: [extension],
-    };
-
-    expect(isDataReceiver(item)).toBeTruthy();
-  });
-
-  it('ItemControl is help, should return false', () => {
-    const extension = createItemControlExtension(itemcontrol.HELP);
-    const item: QuestionnaireItem = {
-      linkId: '2.1',
-      type: 'string',
-      extension: [extension],
-    };
-
-    expect(isDataReceiver(item)).toBeFalsy();
-  });
-});
-
-describe('getLinkIdFromCopyExpression', () => {
-  const testData = [
-    { input: 'valueInteger', itemType: 'integer' },
-    { input: 'value', itemType: 'quantity' },
-    { input: 'valueDecimal', itemType: 'decimal' },
-    { input: 'valueDateTime', itemType: 'date' },
-    { input: 'valueTime', itemType: 'time' },
-    { input: 'valueString', itemType: 'text' },
-    { input: 'valueString', itemType: 'string' },
-    { input: 'choice', itemType: 'valueCoding.system' },
-  ];
-
-  test.each(testData)('Questionnaire ItemType is %s', data => {
-    const extension = {
-      url: extensionConstants.Copy_EXPRESSION,
-      valueString: `QuestionnaireResponse.descendants().where(linkId='24655ca8-7802-47d2-80a0-faa5bd6d0645').answer.value.${data.input}}`,
-    };
-    const item: QuestionnaireItem = {
-      linkId: '2.1',
-      type: data.itemType,
-      extension: [extension],
-    };
-    expect(getLinkIdFromCopyExpression(item)).toBe('24655ca8-7802-47d2-80a0-faa5bd6d0645');
+  describe('getCopyExtension', () => {
+    it('should return extension', () => {
+      const extension: Extension = {
+        url: extensionConstants.Copy_EXPRESSION,
+        valueString: 'Du må fylle ut feltet',
+      } as Extension;
+      const item: QuestionnaireItem = {
+        linkId: '2.1',
+        type: 'group',
+        extension: [extension],
+      };
+      expect(getCopyExtension(item)).toEqual(extension);
+    });
   });
 });

--- a/src/util/extension.ts
+++ b/src/util/extension.ts
@@ -160,14 +160,6 @@ export function getRepeatsTextExtension(item: QuestionnaireItem): string | undef
   return repeatsTextExtension.valueString;
 }
 
-export function getCopyExtension(item: QuestionnaireItem): string | undefined {
-  const extension = getExtension(ExtensionConstants.Copy_EXPRESSION, item);
-  if (!extension || !extension.valueString) {
-    return undefined;
-  }
-  return extension.valueString;
-}
-
 export function getItemControlExtensionValue(item: QuestionnaireItem): Coding[] | undefined {
   const itemControlExtension = getExtension(ExtensionConstants.ITEMCONTROL_URL, item);
   if (!itemControlExtension || !itemControlExtension.valueCodeableConcept || !itemControlExtension.valueCodeableConcept.coding) {
@@ -212,22 +204,18 @@ export function getCalculatedExpressionExtension(item: QuestionnaireItem): Exten
   return calculatedExpressionExtension;
 }
 
+export function getCopyExtension(item: QuestionnaireItem): Extension | undefined {
+  const extension = getExtension(ExtensionConstants.Copy_EXPRESSION, item);
+  if (!extension || !extension.valueString) {
+    return;
+  }
+  return extension;
+}
+
 export function getHyperlinkExtensionValue(item: QuestionnaireItem | Element | Questionnaire): number | undefined {
   const hyperlinkExtension = getExtension(ExtensionConstants.HYPERLINK, item);
   if (hyperlinkExtension && hyperlinkExtension.valueCoding && hyperlinkExtension.valueCoding.code) {
     return parseInt(hyperlinkExtension.valueCoding.code);
   }
   return undefined;
-}
-
-export function getLinkIdFromCopyExpression(item: QuestionnaireItem): string | undefined {
-  const extensionValueString = getCopyExtension(item) ?? '';
-  const startIndex = extensionValueString.indexOf("'") + 1;
-  const endIndex = extensionValueString.indexOf("')");
-  return extensionValueString.substring(startIndex, endIndex);
-}
-
-export function isDataReceiver(item: QuestionnaireItem): boolean | undefined {
-  const itemControll = getItemControlExtensionValue(item);
-  return itemControll?.some(s => s.code === itemControlConstants.DATARECEIVER);
 }

--- a/src/util/extension.ts
+++ b/src/util/extension.ts
@@ -160,6 +160,14 @@ export function getRepeatsTextExtension(item: QuestionnaireItem): string | undef
   return repeatsTextExtension.valueString;
 }
 
+export function getCopyExtension(item: QuestionnaireItem): string | undefined {
+  const extension = getExtension(ExtensionConstants.Copy_EXPRESSION, item);
+  if (!extension || !extension.valueString) {
+    return undefined;
+  }
+  return extension.valueString;
+}
+
 export function getItemControlExtensionValue(item: QuestionnaireItem): Coding[] | undefined {
   const itemControlExtension = getExtension(ExtensionConstants.ITEMCONTROL_URL, item);
   if (!itemControlExtension || !itemControlExtension.valueCodeableConcept || !itemControlExtension.valueCodeableConcept.coding) {
@@ -210,4 +218,16 @@ export function getHyperlinkExtensionValue(item: QuestionnaireItem | Element | Q
     return parseInt(hyperlinkExtension.valueCoding.code);
   }
   return undefined;
+}
+
+export function getLinkIdFromCopyExpression(item: QuestionnaireItem): string | undefined {
+  const extensionValueString = getCopyExtension(item) ?? '';
+  const startIndex = extensionValueString.indexOf("'") + 1;
+  const endIndex = extensionValueString.indexOf("')");
+  return extensionValueString.substring(startIndex, endIndex);
+}
+
+export function isDataReceiver(item: QuestionnaireItem): boolean | undefined {
+  const itemControll = getItemControlExtensionValue(item);
+  return itemControll?.some(s => s.code === itemControlConstants.DATARECEIVER);
 }

--- a/src/util/fhirpathHelper.ts
+++ b/src/util/fhirpathHelper.ts
@@ -1,14 +1,27 @@
-import { QuestionnaireItem } from '../types/fhir';
+import { QuestionnaireItem, Extension, QuestionnaireResponse } from '../types/fhir';
 
 import r4 from './fhirpathLoaderHelper';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fhirpath = require('fhirpath');
+const fhirpath_r4_model = require('fhirpath/fhir-context/r4');
 
 export function evaluateFhirpathExpressionToGetDate(item: QuestionnaireItem, fhirExpression: string): Date | undefined {
   const result = fhirpath.evaluate(item, fhirExpression, null, r4);
   if (result.length > 0) {
     return new Date(result[0].asStr);
+  }
+
+  return;
+}
+
+export function evaluateFhirpathExpressionToGetString(
+  questionnare: QuestionnaireResponse | null | undefined,
+  fhirExtension: Extension
+): string | undefined {
+  const result = fhirpath.evaluate(questionnare, fhirExtension.valueString, null, fhirpath_r4_model);
+  if (result.length > 0) {
+    return result[0];
   }
 
   return;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -35,6 +35,8 @@ import {
   getExtension,
   getSublabelExtensionValue,
   getHyperlinkExtensionValue,
+  isDataReceiver,
+  getLinkIdFromCopyExpression,
 } from './extension';
 import { getQuestionnaireItemCodeValue } from './codingsystem';
 
@@ -123,6 +125,17 @@ export function isHiddenItem(item: QuestionnaireItem): boolean | undefined {
     getQuestionnaireHiddenExtensionValue(item) ||
     getQuestionnaireItemCodeValue(item, CodingSystemConstants.RenderingOptions) === RenderOptionCode.KunPdf
   );
+}
+
+export function getCopyValue(
+  item: QuestionnaireItem,
+  response: QuestionnaireResponseItem | undefined
+): QuestionnaireResponseItem[] | undefined {
+  if (isDataReceiver(item)) {
+    const linkid = getLinkIdFromCopyExpression(item);
+    return response?.item?.filter(f => f.linkId === linkid);
+  }
+  return undefined;
 }
 
 export function getId(id?: string): string {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -35,8 +35,7 @@ import {
   getExtension,
   getSublabelExtensionValue,
   getHyperlinkExtensionValue,
-  isDataReceiver,
-  getLinkIdFromCopyExpression,
+  getCopyExtension,
 } from './extension';
 import { getQuestionnaireItemCodeValue } from './codingsystem';
 
@@ -120,22 +119,15 @@ export function isRepeat(item: QuestionnaireItem): boolean {
   return false;
 }
 
+export function isDataReciever(item: QuestionnaireItem): boolean {
+  return getCopyExtension(item) !== undefined;
+}
+
 export function isHiddenItem(item: QuestionnaireItem): boolean | undefined {
   return (
     getQuestionnaireHiddenExtensionValue(item) ||
     getQuestionnaireItemCodeValue(item, CodingSystemConstants.RenderingOptions) === RenderOptionCode.KunPdf
   );
-}
-
-export function getCopyValue(
-  item: QuestionnaireItem,
-  response: QuestionnaireResponseItem | undefined
-): QuestionnaireResponseItem[] | undefined {
-  if (isDataReceiver(item)) {
-    const linkid = getLinkIdFromCopyExpression(item);
-    return response?.item?.filter(f => f.linkId === linkid);
-  }
-  return undefined;
 }
 
 export function getId(id?: string): string {

--- a/src/util/map-props.ts
+++ b/src/util/map-props.ts
@@ -1,14 +1,22 @@
 import { ThunkDispatch } from 'redux-thunk';
 
-import { QuestionnaireResponseItem, QuestionnaireItemEnableWhen, QuestionnaireItemEnableBehaviorCodes } from '../types/fhir';
+import {
+  QuestionnaireResponseItem,
+  QuestionnaireItemEnableWhen,
+  QuestionnaireItemEnableBehaviorCodes,
+  QuestionnaireResponseItemAnswer,
+} from '../types/fhir';
 
 import { NewValueAction } from '../actions/newValue';
 import { Props } from '../components/with-common-functions';
 import { getFormData } from '../reducers/form';
 import { GlobalState } from '../reducers/index';
 import { enableWhenMatchesAnswer, getQuestionnaireResponseItemWithLinkid, getResponseItems, Path, isInGroupContext } from './refero-core';
+import { getCopyExtension } from '../util/extension';
+import { evaluateFhirpathExpressionToGetString } from '../util/fhirpathHelper';
 
 export function mapStateToProps(state: GlobalState, originalProps: Props): Props {
+  getValueIfDataReciever(state, originalProps);
   if (!originalProps.item || !originalProps.item.enableWhen) {
     return { ...originalProps, enable: true } as Props;
   }
@@ -45,6 +53,39 @@ function isEnableWhenEnabled(
   return enableBehavior === QuestionnaireItemEnableBehaviorCodes.ALL
     ? enableMatches.every(x => x === true)
     : enableMatches.some(x => x === true);
+}
+
+function getValueIfDataReciever(state: GlobalState, originalProps: Props): void {
+  if (originalProps.item) {
+    const extension = getCopyExtension(originalProps.item);
+    if (extension) {
+      const formData = getFormData(state);
+      const result = evaluateFhirpathExpressionToGetString(formData?.Content, extension);
+      originalProps.answer = getQuestionnaireResponseItemAnswer(originalProps.item.type, result);
+    }
+  }
+}
+
+function getQuestionnaireResponseItemAnswer(type: string, result: any): QuestionnaireResponseItemAnswer {
+  switch (type) {
+    case 'text':
+    case 'string':
+      return { valueString: result };
+    case 'integer':
+      return { valueInteger: result };
+    case 'decimal':
+      return { valueDecimal: result };
+    case 'dateTime':
+      return { valueDateTime: result };
+    case 'date':
+      return { valueDate: result };
+    case 'boolean':
+      return { valueBoolean: result };
+    case 'quantity':
+      return { valueQuantity: result };
+    default:
+      return { valueCoding: result };
+  }
 }
 
 export function mergeProps(stateProps: Props, dispatchProps: Props, ownProps: Props): Props {


### PR DESCRIPTION
**Behov**
I mange situasjoner er det et behov for å kopiere dataelementer og innhold flere steder i skjemaet, samt gjøre oppslag og beregninger basert på data et sted, som skal få konsekvenser et annet sted. 

En kompliserende faktor det må tas høyde for er repeterende elementer. For eksempel at en innbygger oppgir ulike allergier eller legemidler, og en ønsker disse kopiert til et annet felt i en oppsummering til helsepersonell. 

**Eksempler:**

- HSØ har behov for at noen nøkkeldata kopieres til en egen oppsummering for helsepersonell, slik at de kan lese relevante data som er kritisk å få en rask oversikt over. 

- HV har et behov som tilsvarer det HSØ har. I tillegg ønskes det at det gjørs en del beregninger på tvers av skjemaet, der en bruker ulike fhir-path uttrykk. 