### PR TITLE
Made renderChildrenWhenClosed into a prop in text.tsx

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@
 - Upgraded helsenorge packages to version 26.x.x
 - Upgraded third party libraries to the same versions used in the helsenorge v26 packages
 - Replaced deprecated prop in an instance of the Button component
+- Created a new prop in Text.tsx: "shouldExpanderRenderChildrenWhenClosed". It is used in the Expander component to decide if it's children
+  should be rendered if the Expander is closed.
 
 ## 10.4.0-beta01
 

--- a/src/components/formcomponents/text/__tests__/text-spec.tsx
+++ b/src/components/formcomponents/text/__tests__/text-spec.tsx
@@ -33,6 +33,7 @@ describe('text with inline extension', () => {
         renderHelpElement={() => <React.Fragment />}
         onAnswerChange={() => {}}
         responseItem={{} as QuestionnaireResponseItem}
+        shouldExpanderRenderChildrenWhenClosed={true}
       >
         {children}
       </Text>

--- a/src/components/formcomponents/text/text.tsx
+++ b/src/components/formcomponents/text/text.tsx
@@ -58,6 +58,7 @@ export interface Props {
   onAnswerChange: (newState: GlobalState, path: Array<Path>, item: QuestionnaireItem, answer: QuestionnaireResponseItemAnswer) => void;
   isHelpOpen?: boolean;
   onRenderMarkdown?: (item: QuestionnaireItem, markdown: string) => string;
+  shouldExpanderRenderChildrenWhenClosed?: boolean;
 }
 export class Text extends React.Component<Props & ValidationProps, {}> {
   showCounter(): boolean {
@@ -128,7 +129,10 @@ export class Text extends React.Component<Props & ValidationProps, {}> {
     if (itemControls && itemControls.some(itemControl => itemControl.code === itemControlConstants.INLINE)) {
       return (
         <div id={id} className="page_refero__component page_refero__component_expandabletext">
-          <Expander title={item.text ? item.text : ''} renderChildrenWhenClosed>
+          <Expander
+            title={item.text ? item.text : ''}
+            renderChildrenWhenClosed={this.props.shouldExpanderRenderChildrenWhenClosed ? true : false}
+          >
             <React.Fragment>{children}</React.Fragment>
           </Expander>
         </div>


### PR DESCRIPTION
This was to fix a test that couldn't read the children of the Expander component because it didn't render. This was caused by an update to the Expander component in the Designsystem-React package.