### PR TITLE
Small bugfix date-day-input: Removing undefined check in getValue method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+## 11.3.8
+
+---
+
+- Small fix in date-day-input component: Removing misplaced undefined check 
+
 ## 11.3.7
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helsenorge/refero",
-  "version": "11.3.7",
+  "version": "11.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@helsenorge/refero",
-      "version": "11.3.7",
+      "version": "11.3.8",
       "license": "MIT",
       "dependencies": {
         "@types/react-collapse": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "11.3.7",
+  "version": "11.3.8",
   "main": "index.js",
   "author": "helsenorge",
   "license": "MIT",

--- a/src/components/formcomponents/date/date-day-input.tsx
+++ b/src/components/formcomponents/date/date-day-input.tsx
@@ -66,7 +66,7 @@ export class DateDayInput extends React.Component<Props, {}> {
       return answer.map(m => parseDate(String(this.getDateAnswerValue(m))));
     }
 
-    if (answer && Array.isArray(item.initial)) {
+    if (Array.isArray(item.initial)) {
       return item.initial.map(m => parseDate(String(this.getDateAnswerValue(m))));
     }
 


### PR DESCRIPTION
The last PR missed the actual code change. This PR resolves this.