### PR TITLE
Bug fix: Support enable when for new Vite Structor and Jest fix

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,16 +1,18 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-'use strict';
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-global.define = () => {};
+// Setting up enzyme for use with React based on node 18 requirements
+Enzyme.configure({
+  adapter: new Adapter(),
+  disableLifecycleMethods: true,
+});
 
-var _enzymeAdapterReact = require('@wojtekmaj/enzyme-adapter-react-17');
-var _enzyme = require('enzyme');
-var _enzymeAdapterReact2 = _interopRequireDefault(_enzymeAdapterReact);
+/*  The structured clone global is needed to fix error: "StructuredCopy is not defined"
+ *  Ended up using ungap npm package to resolve this:
+ *     1) It it is very similar to structuredClone ( which is needed for some of the tests that do actual deep copies )
+ *     2) Avoid complications using a hybrid of test environments for different tests
+ *     3) The package seems stable ( lot of downloads )
+ */
 
-// Setting up enzyme for use with react 16
-(0, _enzyme.configure)({ adapter: new _enzymeAdapterReact2.default(), disableLifecycleMethods: true });
-
-function _interopRequireDefault(obj) {
-  return obj && obj.__esModule ? obj : { default: obj };
-}
+import structuredClone from '@ungap/structured-clone';
+global.structuredClone = global.structuredClone || structuredClone;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helsenorge/refero",
-  "version": "13.2.2-beta02",
+  "version": "13.2.3-beta01",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@helsenorge/refero",
-      "version": "13.2.2-beta02",
+      "version": "13.2.3-beta01",
       "license": "MIT",
       "dependencies": {
         "@types/react-collapse": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helsenorge/refero",
-  "version": "13.2.2",
+  "version": "13.2.2-beta02",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@helsenorge/refero",
-      "version": "13.2.2",
+      "version": "13.2.2-beta02",
       "license": "MIT",
       "dependencies": {
         "@types/react-collapse": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@types/yargs": "^17.0.24",
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",
+        "@ungap/structured-clone": "^1.2.0",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
         "babel-jest": "^27.4.2",
         "babel-loader": "^8.2.3",
@@ -4022,6 +4023,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -16895,6 +16902,12 @@
         "@typescript-eslint/types": "5.12.0",
         "eslint-visitor-keys": "^3.0.0"
       }
+    },
+    "@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "13.2.2-beta04",
+  "version": "13.2.3-beta01",
   "engines": {
     "node": "^18.0.0",
     "npm": ">=9.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "13.2.2-beta02",
+  "version": "13.2.2-beta04",
   "engines": {
     "node": "^18.0.0",
     "npm": ">=9.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "13.2.2",
+  "version": "13.2.2-beta02",
   "engines": {
     "node": "^18.0.0",
     "npm": ">=9.0.0"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/yargs": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
     "@typescript-eslint/parser": "^5.12.0",
+    "@ungap/structured-clone": "^1.2.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
     "babel-jest": "^27.4.2",
     "babel-loader": "^8.2.3",

--- a/src/util/fhirpathHelper.ts
+++ b/src/util/fhirpathHelper.ts
@@ -18,6 +18,17 @@ export function evaluateFhirpathExpressionToGetDate(item: QuestionnaireItem, fhi
 export function evaluateFhirpathExpressionToGetString(
   questionnare: QuestionnaireResponse | null | undefined,
   fhirExtension: Extension
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
-  return fhirpath.evaluate(questionnare, fhirExtension.valueString, null, fhirpath_r4_model);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let result: any;
+  const qCopy = structuredClone(questionnare);
+  const extCopy = structuredClone(fhirExtension);
+  try {
+    result = fhirpath.evaluate(qCopy, extCopy.valueString, null, fhirpath_r4_model);
+  } catch (e) {
+    return [];
+  }
+
+  return result;
 }


### PR DESCRIPTION
- When using Vite in Structor enable when failed to a typeerror "cannot update read only prop"
- Change fhirPath helper to use structuredClone to resolve read only error in Structor
- Adds support in jest for tests using structuredClone directly/indirectly using ungap ( structured clone polyfill )
- Simplify/ removes old setup for Enzyme adapter and updates it for node 18