### PR TITLE
fix: Validate max file size for attachments

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+## 13.2.4-beta02
+
+---
+
+- Bug fix: Max size on attachments set in questionaire-extention is used to validate the file in stead of hard coded value of 4MB
+
 ## 13.2.2
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helsenorge/refero",
-  "version": "13.2.3",
+  "version": "13.2.4-beta02",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@helsenorge/refero",
-      "version": "13.2.3",
+      "version": "13.2.4-beta02",
       "license": "MIT",
       "dependencies": {
         "@types/react-collapse": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "13.2.3",
+  "version": "13.2.4-beta02",
   "engines": {
     "node": "^18.0.0",
     "npm": ">=9.0.0"

--- a/src/components/formcomponents/attachment/__tests__/attachment-spec.tsx
+++ b/src/components/formcomponents/attachment/__tests__/attachment-spec.tsx
@@ -1,0 +1,21 @@
+import { QuestionnaireItem } from '../../../../types/fhir';
+import { getMaxSizeExtensionValue } from '../../../../util/extension';
+
+describe('Attachment form component', () => {
+  const question: QuestionnaireItem = {
+    linkId: '4c71df6e-d743-46ba-d81f-f62777ffddb4',
+    type: 'attachment',
+    text: '5mb',
+    extension: [
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/maxSize',
+        valueDecimal: 5,
+      },
+    ],
+  };
+  it('Should give back right value in MB',
+    () => {
+      const test = getMaxSizeExtensionValue(question);
+      expect(test).toBe(5);
+    });
+});

--- a/src/components/formcomponents/attachment/__tests__/attachment-spec.tsx
+++ b/src/components/formcomponents/attachment/__tests__/attachment-spec.tsx
@@ -2,7 +2,7 @@ import { QuestionnaireItem } from '../../../../types/fhir';
 import { getMaxSizeExtensionValue } from '../../../../util/extension';
 
 describe('Attachment form component', () => {
-  const question: QuestionnaireItem = {
+  const questionExtention: QuestionnaireItem = {
     linkId: '4c71df6e-d743-46ba-d81f-f62777ffddb4',
     type: 'attachment',
     text: '5mb',
@@ -13,9 +13,17 @@ describe('Attachment form component', () => {
       },
     ],
   };
-  it('Should give back right value in MB',
-    () => {
-      const test = getMaxSizeExtensionValue(question);
-      expect(test).toBe(5);
-    });
+  it('Should give back right value from extention in MB', () => {
+    const test = getMaxSizeExtensionValue(questionExtention);
+    expect(test).toBe(5);
+  });
+  const question: QuestionnaireItem = {
+    linkId: '4c71df6e-d743-46ba-d81f-f62777ffddb4',
+    type: 'attachment',
+    text: 'No extention',
+  };
+  it('Should fail to undefined without extention', () => {
+    const test = getMaxSizeExtensionValue(question);
+    expect(test).toBe(undefined);
+  });
 });

--- a/src/components/formcomponents/attachment/attachmenthtml.tsx
+++ b/src/components/formcomponents/attachment/attachmenthtml.tsx
@@ -11,7 +11,7 @@ import { sizeIsValid, mimeTypeIsValid } from '@helsenorge/file-upload/components
 import Validation, { ValidationProps } from '@helsenorge/form/components/form/validation';
 
 import constants, { VALID_FILE_TYPES } from '../../../constants';
-import { getValidationTextExtension } from '../../../util/extension';
+import { getMaxSizeExtensionValue, getValidationTextExtension } from '../../../util/extension';
 import { Resources } from '../../../util/resources';
 
 interface Props {
@@ -65,7 +65,12 @@ const attachmentHtml: React.SFC<Props & ValidationProps> = ({
   children,
   ...other
 }) => {
-  const maxFilesize = attachmentMaxFileSize ? attachmentMaxFileSize : constants.MAX_FILE_SIZE;
+  const maxValueFromQuestionaire = getMaxSizeExtensionValue(item);
+  const maxFilesize = maxValueFromQuestionaire
+    ? maxValueFromQuestionaire * 1024 * 1024
+    : attachmentMaxFileSize
+    ? attachmentMaxFileSize
+    : constants.MAX_FILE_SIZE;
   const validFileTypes = attachmentValidTypes ? attachmentValidTypes : VALID_FILE_TYPES;
   const deleteText = resources ? resources.deleteAttachmentText : undefined;
 
@@ -118,7 +123,7 @@ function getErrorMessage(
     if (!mimeTypeIsValid(file, validFileTypes)) {
       return resources.validationFileType;
     } else if (!sizeIsValid(file, maxFileSize)) {
-      return resources.validationFileMax;
+      return resources.validationFileMax.replace('25', (maxFileSize / 1024 / 1024).toString());
     }
   }
 

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -12,6 +12,7 @@ export default {
   MARKDOWN_URL: 'http://hl7.org/fhir/StructureDefinition/rendering-markdown',
   QUESTIONNAIRE_HIDDEN: 'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden',
   ORDINAL_VALUE: 'http://hl7.org/fhir/StructureDefinition/ordinalValue',
+  MAX_SIZE_URL: 'http://hl7.org/fhir/StructureDefinition/maxSize',
 
   VALIDATIONTEXT_URL: 'http://ehelse.no/fhir/StructureDefinition/validationtext',
   REPEATSTEXT_URL: 'http://ehelse.no/fhir/StructureDefinition/repeatstext',

--- a/src/util/extension.ts
+++ b/src/util/extension.ts
@@ -103,6 +103,17 @@ export function getQuestionnaireUnitExtensionValue(item: QuestionnaireItem): Cod
   return extension.valueCoding;
 }
 
+export function getMaxSizeExtensionValue(item: QuestionnaireItem): number | undefined {
+  const maxValue = getExtension(ExtensionConstants.MAX_SIZE_URL, item);
+  if (maxValue && maxValue.valueDecimal !== null && maxValue.valueDecimal !== undefined) {
+    return Number(maxValue.valueDecimal);
+  }
+  if (maxValue && maxValue.valueInteger !== null && maxValue.valueInteger !== undefined) {
+    return Number(maxValue.valueInteger);
+  }
+  return undefined;
+}
+
 export function getMaxValueExtensionValue(item: QuestionnaireItem): number | undefined {
   const maxValue = getExtension(ExtensionConstants.MAX_VALUE_URL, item);
   if (maxValue && maxValue.valueDecimal !== null && maxValue.valueDecimal !== undefined) {


### PR DESCRIPTION
Uses questionaire item to set the max file size to validate with Dropzone. 

Default is 4MB