### PR TITLE
Rubenr/support sublabel text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 23.2.0
+
+- Sublabel now accepts text through an extension sdf-sublabel-text, which is used if the sdf-sublabel extension is not present. This allows
+  for a simple sublabel without markdown formatting, and also allows for screen readers to read the sublabel text without reading markdown
+  formatting.
+
 ## 23.1.3
 
 - merge 23.1.2 into master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "23.1.3",
+  "version": "23.2.0",
   "description": "Refero is a library that uses a fhir r4 schema and creates a interactive form using helsenorge packages.",
   "keywords": [
     "react",

--- a/preview/FormFillerPreview.tsx
+++ b/preview/FormFillerPreview.tsx
@@ -28,7 +28,7 @@ import { ImageChoicePlugin } from './external-components/ImageChoicePlugin';
 import { PillChoicePlugin } from './external-components/PillChoicePlugin';
 import { emptyPropertyReplacer } from './helpers';
 import { getResources } from './resources/referoResources';
-import skjema from './skjema/q-plugin-test.json';
+import skjema from './skjema/q.json';
 import ReferoContainer from '../src/components/index';
 import qr from './skjema/responses/qr.json';
 import valueSet from '../src/constants/valuesets';

--- a/preview/skjema/q.json
+++ b/preview/skjema/q.json
@@ -1,17 +1,13 @@
 {
+  "title": "Skjema med markdown i extender",
   "resourceType": "Questionnaire",
   "language": "nb-NO",
+  "name": "Markdown_extender_display_item",
   "status": "draft",
   "publisher": "NHN",
   "meta": {
     "profile": ["http://ehelse.no/fhir/StructureDefinition/sdf-Questionnaire"],
-    "tag": [
-      {
-        "system": "urn:ietf:bcp:47",
-        "code": "nb-NO",
-        "display": "Bokmål"
-      }
-    ],
+    "tag": [{ "system": "urn:ietf:bcp:47", "code": "nb-NO", "display": "Bokmål" }],
     "security": [
       {
         "code": "3",
@@ -20,11 +16,7 @@
       }
     ]
   },
-  "contact": [
-    {
-      "name": "http://www.nhn.no"
-    }
-  ],
+  "contact": [{ "name": "http://www.nhn.no" }],
   "subjectType": ["Patient"],
   "extension": [
     {
@@ -59,78 +51,20 @@
       }
     }
   ],
-  "id": "ce4ab428-bc96-4d54-844d-bb81d734e775",
-  "url": "Questionnaire/ce4ab428-bc96-4d54-844d-bb81d734e775",
+  "id": "2af89186-d865-4fa4-8d0b-c4438ae699f7",
+  "url": "Questionnaire/2af89186-d865-4fa4-8d0b-c4438ae699f7",
+  "version": "1.0.0",
+  "date": "2026-04-28T00:00:00+02:00",
   "item": [
     {
-      "linkId": "8634a330-6adc-407a-899d-ad4427ac3ed5",
+      "linkId": "9c80f38f-1fd5-44d3-bbe2-e1b602ddd91f",
       "type": "group",
-      "text": "asdadasd",
+      "text": "Gruppe med utvidet text",
       "item": [
         {
-          "linkId": "f218c849-f34d-49e2-8019-1011699c4cec",
-          "type": "choice",
-          "text": "Slider",
-          "code": [
-            {
-              "code": "label",
-              "display": "Display value",
-              "system": "http://helsenorge.no/fhir/CodeSystem/SliderDisplayType"
-            },
-            {
-              "code": "LabelLeft",
-              "system": "http://helsenorge.no/fhir/CodeSystem/SliderLabels"
-            },
-            {
-              "code": "LabelRight",
-              "system": "http://helsenorge.no/fhir/CodeSystem/SliderLabels"
-            }
-          ],
-          "required": false,
-          "answerOption": [
-            {
-              "valueCoding": {
-                "id": "f2774d79-f7f1-464d-84b2-0876097af82f",
-                "code": "1",
-                "system": "urn:uuid:30d62dc7-a3a3-4037-8c9c-676e3aa6ac72",
-                "display": "1",
-                "extension": [
-                  {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 1
-                  }
-                ]
-              }
-            },
-            {
-              "valueCoding": {
-                "id": "13ae6963-3cfb-434e-8d12-6d6aedee698d",
-                "code": "2",
-                "system": "urn:uuid:30d62dc7-a3a3-4037-8c9c-676e3aa6ac72",
-                "display": "2",
-                "extension": [
-                  {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 2
-                  }
-                ]
-              }
-            },
-            {
-              "valueCoding": {
-                "id": "0d2a498d-f5a2-426a-8913-de9a8526a6a4",
-                "code": "3",
-                "system": "urn:uuid:30d62dc7-a3a3-4037-8c9c-676e3aa6ac72",
-                "display": "3",
-                "extension": [
-                  {
-                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                    "valueDecimal": 3
-                  }
-                ]
-              }
-            }
-          ],
+          "linkId": "02ad05f6-1b9b-497e-85c5-ca085d05bc63",
+          "type": "text",
+          "text": "Utvidet text med markdown",
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -138,13 +72,84 @@
                 "coding": [
                   {
                     "system": "http://hl7.org/fhir/ValueSet/questionnaire-item-control",
-                    "code": "slider"
+                    "code": "inline"
                   }
                 ]
               }
             }
           ],
-          "repeats": true
+          "item": [
+            {
+              "linkId": "a0e0e127-07c2-41f3-830e-258d3c1f84a8",
+              "type": "display",
+              "required": false,
+              "_text": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/rendering-markdown",
+                    "valueMarkdown": "**Bold**\n\n*italic*\n\n***bold-italic***\n\n[link](https://vg.no)\n\n[***LINK***](https://vg.no)\n\n## h2\n\n### h3\n\n#### h4\n\n- bullet\n- list\n\n1. number\n2. list\n\n- **bullet**\n- **list**\n- **bold**\n\n- *bullet*\n- *list*\n- *italic*\n\n- ***bullet***\n- ***list***\n- ***bold***\n- ***italic***\n\n1. **number**\n2. **list**\n3. **bold**\n\n1. *number*\n2. *list*\n3. *bold*\n\n1. ***number***\n2. ***list***\n3. ***bold***\n4. ***italic***"
+                  }
+                ]
+              },
+              "text": "Bold\n\nitalic\n\nbold-italic\n\nlink\n\nLINK\n\nh2\n\nh3\n\nh4\n\nbullet\n\nlist\n\nnumber\n\nlist\n\nbullet\n\nlist\n\nbold\n\nbullet\n\nlist\n\nitalic\n\nbullet\n\nlist\n\nbold\n\nitalic\n\nnumber\n\nlist\n\nbold\n\nnumber\n\nlist\n\nbold\n\n\n\nnumber\n\nlist\n\nbold\n\nitalic"
+            }
+          ],
+          "required": false
+        },
+        {
+          "linkId": "6d7b60ac-4c0b-4380-8a60-73e3a49eae49",
+          "type": "text",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/ValueSet/questionnaire-item-control",
+                    "code": "inline"
+                  }
+                ]
+              }
+            }
+          ],
+          "item": [
+            {
+              "linkId": "c703d0e6-c6c9-43d2-842e-db74d575a0be",
+              "type": "display",
+              "required": false,
+              "_text": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/rendering-markdown",
+                    "valueMarkdown": "## ***fsdfsfsfsdf***"
+                  }
+                ]
+              },
+              "text": "fsdfsfsfsdf"
+            }
+          ],
+          "required": false,
+          "_text": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/rendering-markdown",
+                "valueMarkdown": "## **asdasdads**"
+              }
+            ]
+          },
+          "text": "asdasdads"
+        },
+        {
+          "linkId": "c6d87674-2c9c-4efd-bfec-bea1827b2e6b",
+          "type": "string",
+          "text": "LABEL",
+          "extension": [
+            {
+              "url": "http://helsenorge.no/fhir/StructureDefinition/sdf-sublabel-text",
+              "valueString": "SUBLABEL"
+            }
+          ],
+          "required": false
         }
       ],
       "required": false

--- a/src/components/__tests__/utils.ts
+++ b/src/components/__tests__/utils.ts
@@ -130,6 +130,13 @@ export const createSublabelExtension = ({ value, extension }: { extension?: Exte
     url: Extensions.SUBLABEL_URL,
   });
 };
+export const createSublabelTextExtension = ({ value, extension }: { extension?: Extension; value: string }): Extension => {
+  return createExtension({
+    ...(extension && { ...extension }),
+    valueString: value,
+    url: Extensions.SUBLABEL_TEXT_URL,
+  });
+};
 export const createMinValueExtension = ({ value, extension }: { extension?: Extension; value: number }): Extension => {
   return createExtension({
     ...(extension && { ...extension }),

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -24,6 +24,7 @@ export const GUIDANCE_ACTION_URL = 'http://helsenorge.no/fhir/StructureDefinitio
 export const PRESENTATION_BUTTONS_URL = 'http://helsenorge.no/fhir/StructureDefinition/sdf-presentationbuttons' as const;
 export const NAVIGATOR_URL = 'http://helsenorge.no/fhir/StructureDefinition/sdf-questionnaire-navgiator-state' as const;
 export const SUBLABEL_URL = 'http://helsenorge.no/fhir/StructureDefinition/sdf-sublabel' as const;
+export const SUBLABEL_TEXT_URL = 'http://helsenorge.no/fhir/StructureDefinition/sdf-sublabel-text' as const;
 export const HYPERLINK_URL = 'http://helsenorge.no/fhir/StructureDefinition/sdf-hyperlink-target' as const;
 export const VALUESET_LABEL_URL = 'http://hl7.org/fhir/StructureDefinition/valueset-label' as const;
 export const MAX_SIZE_URL = 'http://hl7.org/fhir/StructureDefinition/maxSize' as const;
@@ -69,6 +70,7 @@ const extensionUrls = {
   PRESENTATION_BUTTONS_URL,
   NAVIGATOR_URL,
   SUBLABEL_URL,
+  SUBLABEL_TEXT_URL,
   HYPERLINK_URL,
   VALUESET_LABEL_URL,
   MAX_SIZE_URL,

--- a/src/util/__tests__/util-index-spec.ts
+++ b/src/util/__tests__/util-index-spec.ts
@@ -1,8 +1,123 @@
 import type { Resources } from '../resources';
+import type { QuestionnaireItem } from 'fhir/r4';
 
-import { scriptInjectionValidation } from '..';
+import { scriptInjectionValidation, getSublabelText } from '..';
+import { Extensions } from '../../constants/extensions';
 
 describe('utils-index', () => {
+  describe('getSublabelText', () => {
+    it('should return empty string when item is undefined', () => {
+      expect(getSublabelText(undefined)).toBe('');
+    });
+
+    it('should return empty string when item has no sublabel extensions', () => {
+      const item: QuestionnaireItem = { linkId: '1', type: 'string' };
+      expect(getSublabelText(item)).toBe('');
+    });
+
+    it('should return sublabel text from sdf-sublabel-text extension', () => {
+      const item: QuestionnaireItem = {
+        linkId: '1',
+        type: 'string',
+        extension: [
+          {
+            url: Extensions.SUBLABEL_TEXT_URL,
+            valueString: 'Plain sublabel text',
+          },
+        ],
+      };
+      expect(getSublabelText(item)).toBe('Plain sublabel text');
+    });
+
+    it('should return rendered markdown from sdf-sublabel extension when both extensions are present', () => {
+      const item: QuestionnaireItem = {
+        linkId: '1',
+        type: 'string',
+        extension: [
+          {
+            url: Extensions.SUBLABEL_URL,
+            valueMarkdown: '**bold sublabel**',
+          },
+          {
+            url: Extensions.SUBLABEL_TEXT_URL,
+            valueString: 'Plain sublabel text',
+          },
+        ],
+      };
+      const result = getSublabelText(item);
+      expect(result).toContain('<strong>bold sublabel</strong>');
+    });
+
+    it('should prefer markdown sublabel over plain text sublabel', () => {
+      const item: QuestionnaireItem = {
+        linkId: '1',
+        type: 'string',
+        extension: [
+          {
+            url: Extensions.SUBLABEL_URL,
+            valueMarkdown: '**bold**',
+          },
+          {
+            url: Extensions.SUBLABEL_TEXT_URL,
+            valueString: 'plain text',
+          },
+        ],
+      };
+      const result = getSublabelText(item);
+      expect(result).not.toBe('plain text');
+      expect(result).toContain('<strong>bold</strong>');
+    });
+
+    it('should use onRenderMarkdown callback when provided with markdown sublabel', () => {
+      const item: QuestionnaireItem = {
+        linkId: '1',
+        type: 'string',
+        extension: [
+          {
+            url: Extensions.SUBLABEL_URL,
+            valueMarkdown: '**bold**',
+          },
+        ],
+      };
+      const onRenderMarkdown = (_item: QuestionnaireItem, markdown: string): string => `<custom>${markdown}</custom>`;
+      const result = getSublabelText(item, onRenderMarkdown);
+      expect(result).toBe('<custom>**bold**</custom>');
+    });
+
+    it('should not use onRenderMarkdown callback when only plain text sublabel is present', () => {
+      const item: QuestionnaireItem = {
+        linkId: '1',
+        type: 'string',
+        extension: [
+          {
+            url: Extensions.SUBLABEL_TEXT_URL,
+            valueString: 'Plain text',
+          },
+        ],
+      };
+      const onRenderMarkdown = (_item: QuestionnaireItem, markdown: string): string => `<custom>${markdown}</custom>`;
+      const result = getSublabelText(item, onRenderMarkdown);
+      expect(result).toBe('Plain text');
+    });
+
+    it('should return plain text sublabel when markdown sublabel extension has no value', () => {
+      const item: QuestionnaireItem = {
+        linkId: '1',
+        type: 'string',
+        extension: [
+          {
+            url: Extensions.SUBLABEL_URL,
+          },
+          {
+            url: Extensions.SUBLABEL_TEXT_URL,
+            valueString: 'Fallback text',
+          },
+        ],
+      };
+      expect(getSublabelText(item)).toBe('Fallback text');
+    });
+  });
+
   describe('scriptInjectionValidation', () => {
     it('should return resource.validationNotAllowed if script is in value and resources.validationNotAllowed is defined', () => {
       const value = '<script>alert("Hello")</script>';

--- a/src/util/extension.ts
+++ b/src/util/extension.ts
@@ -229,6 +229,13 @@ export function getSublabelExtensionValue(item?: QuestionnaireItem | Element): s
   }
   return markdownExtension.valueMarkdown;
 }
+export function getSublabelTextExtensionValue(item?: QuestionnaireItem | Element): string | undefined {
+  const sublabelTextExtension = getExtension(Extensions.SUBLABEL_TEXT_URL, item);
+  if (!sublabelTextExtension || !sublabelTextExtension.valueString) {
+    return undefined;
+  }
+  return sublabelTextExtension.valueString;
+}
 
 export function getQuestionnaireHiddenExtensionValue(item?: QuestionnaireItem): boolean | undefined {
   const questionnaireHiddenExtension = getExtension(Extensions.QUESTIONNAIRE_HIDDEN_URL, item);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -16,6 +16,7 @@ import {
   getSublabelExtensionValue,
   getHyperlinkExtensionValue,
   getCopyExtension,
+  getSublabelTextExtensionValue,
 } from './extension';
 import codeSystems from '../constants/codingsystems';
 import { Extensions } from '../constants/extensions';
@@ -108,7 +109,8 @@ export function getSublabelText(
 ): string {
   if (item) {
     const markdown = getSublabelExtensionValue(item) || '';
-    return markdown ? getMarkdownValue(markdown, item, onRenderMarkdown, questionnaire, resources?.linkOpensInNewTab) : '';
+    const text = getSublabelTextExtensionValue(item) || '';
+    return markdown ? getMarkdownValue(markdown, item, onRenderMarkdown, questionnaire, resources?.linkOpensInNewTab) : text;
   }
   return '';
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "types": ["vite/client", "vitest/globals", "vitest/jsdom"],
-    "typeRoots": ["./node_modules/@types"],
-    "baseUrl": "."
+    "typeRoots": ["./node_modules/@types"]
   },
   "include": ["src", "test", "preview"],
   "exclude": ["**/__mocks__/*", "**/__data__/*"]


### PR DESCRIPTION
**Add support for `sdf-sublabel-text` plain text extension**

Adds a new `sdf-sublabel-text` extension as a plain text alternative to the existing markdown `sdf-sublabel` extension. When both are present, the markdown sublabel takes precedence. This allows sublabels without markdown formatting and improves screen reader accessibility.

**Changes:**
- New `SUBLABEL_TEXT_URL` constant and `getSublabelTextExtensionValue` extension helper
- Updated `getSublabelText` to fall back to plain text when no markdown sublabel is set
- Added unit tests for `getSublabelText` covering both extensions