### PR TITLE
feat: export OPEN_CHOICE_ID and OPEN_CHOICE_SYSTEM constants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 23.4.0
+
+- Export `OPEN_CHOICE_ID` and `OPEN_CHOICE_SYSTEM` constants for use in external plugin components
+
 ## 23.3.1
 
 - Fix: Add contained resources as prop to plugin component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helsenorge/refero",
-  "version": "23.3.1",
+  "version": "23.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helsenorge/refero",
-      "version": "23.3.1",
+      "version": "23.4.0",
       "license": "MIT",
       "dependencies": {
         "@helsenorge/core-utils": "^38.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "23.3.1",
+  "version": "23.4.0",
   "description": "Refero is a library that uses a fhir r4 schema and creates a interactive form using helsenorge packages.",
   "keywords": [
     "react",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,3 +84,5 @@ export { default as CodingSystemConstants } from './constants/codingsystems';
 export * as ExtensionConstants from './constants/extensions';
 
 export { default as ItemControl } from './constants/itemcontrol';
+
+export { OPEN_CHOICE_ID, OPEN_CHOICE_SYSTEM } from './constants/index';


### PR DESCRIPTION
## Summary
- Re-export `OPEN_CHOICE_ID` ('other') and `OPEN_CHOICE_SYSTEM` from the package entry so external plugin components can identify the "other" option in answers and build the `valueCoding` for the "other" answer.
- Bumped version to 23.4.0 and updated CHANGES.md.
