### PR TITLE
feat!: usePluginDispatch accepts any async thunk + export open-choice…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
-## 23.4.0
+## 24.0.0
 
+- **Breaking**: `usePluginDispatch` now accepts a pre-built async thunk instead of `(action, path, value, item, answer, multipleAnswers?)`.
+  Plugin authors call the action themselves and hand the result to `pluginDispatch`, which makes the hook work with every async action —
+  including `removeCodingStringValueAsync`, `removeCodingValueAsync`, `removeAttachmentAsync`, `toggleCodingValueAsync`,
+  `addRepeatItemAsync`, `deleteRepeatItemAsync`, and `resetAnswerValueAsync`. New `PluginAsyncThunk` type is exported.
 - Export `OPEN_CHOICE_ID` and `OPEN_CHOICE_SYSTEM` constants for use in external plugin components
 
 ## 23.3.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "23.4.0",
+  "version": "24.0.0",
   "description": "Refero is a library that uses a fhir r4 schema and creates a interactive form using helsenorge packages.",
   "keywords": [
     "react",

--- a/src/hooks/__tests__/usePluginDispatch-spec.tsx
+++ b/src/hooks/__tests__/usePluginDispatch-spec.tsx
@@ -7,7 +7,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { Resources } from '@/util/resources';
 import type { QuestionnaireItem } from 'fhir/r4';
 
-import { usePluginDispatch } from '../usePluginDispatch';
+import { usePluginDispatch, type PluginAsyncThunk } from '../usePluginDispatch';
 
 const testItem: QuestionnaireItem = {
   linkId: 'test-item',
@@ -19,11 +19,11 @@ const testItem: QuestionnaireItem = {
  * Test component that uses usePluginDispatch and exposes it via a button click.
  */
 // eslint-disable-next-line react-refresh/only-export-components
-const TestDispatchComponent = ({ action, item }: { action: ReturnType<typeof vi.fn>; item: QuestionnaireItem }): React.JSX.Element => {
+const TestDispatchComponent = ({ thunk, item }: { thunk: PluginAsyncThunk; item: QuestionnaireItem }): React.JSX.Element => {
   const pluginDispatch = usePluginDispatch();
 
   const handleClick = (): void => {
-    pluginDispatch(action, [{ linkId: item.linkId, index: 0 }], 42, item, { valueInteger: 42 });
+    pluginDispatch(thunk, item, { valueInteger: 42 });
   };
 
   return (
@@ -34,13 +34,13 @@ const TestDispatchComponent = ({ action, item }: { action: ReturnType<typeof vi.
 };
 
 describe('usePluginDispatch', () => {
-  it('calls the action with correct arguments when dispatched', async () => {
+  it('dispatches the provided thunk', async () => {
     const mockNewState = { refero: { form: { FormDefinition: { Content: null }, FormData: { Content: null }, Language: 'en' } } };
-    const mockThunk = vi.fn().mockReturnValue(() => Promise.resolve(mockNewState));
+    const mockThunk = vi.fn().mockResolvedValue(mockNewState) as unknown as PluginAsyncThunk;
 
     const store = createPluginTestStore(testItem);
 
-    render(<TestDispatchComponent action={mockThunk} item={testItem} />, {
+    render(<TestDispatchComponent thunk={mockThunk} item={testItem} />, {
       wrapper: ({ children }: { children: React.ReactNode }) => (
         <PluginTestWrapper store={store} referoProps={{ resources: defaultPluginTestResources as Resources }}>
           {children}
@@ -51,49 +51,21 @@ describe('usePluginDispatch', () => {
     fireEvent.click(screen.getByTestId('dispatch-btn'));
 
     await waitFor(() => {
-      expect(mockThunk).toHaveBeenCalledWith(
-        [{ linkId: 'test-item', index: 0 }],
-        42,
-        testItem,
-        undefined // multipleAnswers
-      );
+      expect(mockThunk).toHaveBeenCalled();
     });
   });
 
-  it('dispatches the thunk returned by the action', async () => {
-    const innerThunk = vi.fn().mockResolvedValue({
-      refero: { form: { FormDefinition: { Content: null }, FormData: { Content: null }, Language: 'en' } },
-    });
-    const mockAction = vi.fn().mockReturnValue(innerThunk);
-
-    const store = createPluginTestStore(testItem);
-
-    render(<TestDispatchComponent action={mockAction} item={testItem} />, {
-      wrapper: ({ children }: { children: React.ReactNode }) => (
-        <PluginTestWrapper store={store} referoProps={{ resources: defaultPluginTestResources as Resources }}>
-          {children}
-        </PluginTestWrapper>
-      ),
-    });
-
-    fireEvent.click(screen.getByTestId('dispatch-btn'));
-
-    await waitFor(() => {
-      expect(innerThunk).toHaveBeenCalled();
-    });
-  });
-
-  it('passes multipleAnswers parameter when provided', async () => {
+  it('works without an answer payload (e.g. removeCodingStringValueAsync)', async () => {
     const mockNewState = { refero: { form: { FormDefinition: { Content: null }, FormData: { Content: null }, Language: 'en' } } };
-    const mockAction = vi.fn().mockReturnValue(() => Promise.resolve(mockNewState));
+    const mockThunk = vi.fn().mockResolvedValue(mockNewState) as unknown as PluginAsyncThunk;
 
-    const TestMultipleAnswers = (): React.JSX.Element => {
+    const NoAnswerComponent = (): React.JSX.Element => {
       const pluginDispatch = usePluginDispatch();
       const handleClick = (): void => {
-        pluginDispatch(mockAction, [{ linkId: testItem.linkId, index: 0 }], 42, testItem, { valueInteger: 42 }, true);
+        pluginDispatch(mockThunk, testItem);
       };
       return (
-        <button data-testid="dispatch-multi-btn" onClick={handleClick}>
+        <button data-testid="dispatch-no-answer-btn" onClick={handleClick}>
           {'Dispatch'}
         </button>
       );
@@ -101,7 +73,7 @@ describe('usePluginDispatch', () => {
 
     const store = createPluginTestStore(testItem);
 
-    render(<TestMultipleAnswers />, {
+    render(<NoAnswerComponent />, {
       wrapper: ({ children }: { children: React.ReactNode }) => (
         <PluginTestWrapper store={store} referoProps={{ resources: defaultPluginTestResources as Resources }}>
           {children}
@@ -109,15 +81,10 @@ describe('usePluginDispatch', () => {
       ),
     });
 
-    fireEvent.click(screen.getByTestId('dispatch-multi-btn'));
+    fireEvent.click(screen.getByTestId('dispatch-no-answer-btn'));
 
     await waitFor(() => {
-      expect(mockAction).toHaveBeenCalledWith(
-        [{ linkId: 'test-item', index: 0 }],
-        42,
-        testItem,
-        true // multipleAnswers
-      );
+      expect(mockThunk).toHaveBeenCalled();
     });
   });
 
@@ -138,11 +105,11 @@ describe('usePluginDispatch', () => {
         },
       },
     };
-    const mockAction = vi.fn().mockReturnValue(() => Promise.resolve(mockNewState));
+    const mockThunk = vi.fn().mockResolvedValue(mockNewState) as unknown as PluginAsyncThunk;
 
     const store = createPluginTestStore(testItem);
 
-    render(<TestDispatchComponent action={mockAction} item={testItem} />, {
+    render(<TestDispatchComponent thunk={mockThunk} item={testItem} />, {
       wrapper: ({ children }: { children: React.ReactNode }) => (
         <PluginTestWrapper store={store} referoProps={{ resources: defaultPluginTestResources as Resources, onChange }}>
           {children}

--- a/src/hooks/usePluginDispatch.ts
+++ b/src/hooks/usePluginDispatch.ts
@@ -1,58 +1,42 @@
 import { useCallback } from 'react';
 
-import type { Path } from '@/util/refero-core';
 import type { QuestionnaireItem, QuestionnaireResponseItemAnswer } from 'fhir/r4';
 
 import useOnAnswerChange from './useOnAnswerChange';
 
 import { useExternalRenderContext } from '@/context/externalRender/useExternalRender';
-import { type GlobalState, useAppDispatch } from '@/reducers';
+import { type AppDispatch, type GlobalState, useAppDispatch } from '@/reducers';
 
-type AsyncThunkAction = (
-  path: Path[],
-  value: unknown,
-  item: QuestionnaireItem,
-  multipleAnswers?: boolean
-) => (dispatch: unknown) => Promise<GlobalState>;
+export type PluginAsyncThunk = (dispatch: AppDispatch, getState: () => GlobalState) => Promise<GlobalState>;
 
 /**
  * Hook that simplifies the dispatch + onAnswerChange pattern for plugin authors.
  *
- * Instead of:
- * ```tsx
- * dispatch(newIntegerValueAsync(path, value, item))?.then(newState =>
- *   onAnswerChange(newState, item, { valueInteger: value })
- * );
- * ```
+ * The plugin author builds the thunk by calling any of Refero's async actions
+ * (`newIntegerValueAsync`, `removeCodingStringValueAsync`, `toggleCodingValueAsync`,
+ * `addRepeatItemAsync`, etc.), then hands it to `pluginDispatch` together with the
+ * `item` and the answer payload to broadcast through `onChange`.
  *
- * Plugin authors can write:
  * ```tsx
  * const pluginDispatch = usePluginDispatch();
- * pluginDispatch(newIntegerValueAsync, path, value, item, { valueInteger: value });
+ *
+ * pluginDispatch(newIntegerValueAsync(path, value, item), item, { valueInteger: value });
+ * pluginDispatch(removeCodingStringValueAsync(path, item), item);
+ * pluginDispatch(toggleCodingValueAsync(path, coding, item, isSelected), item, { valueCoding: coding });
  * ```
  */
 export const usePluginDispatch = (): ((
-  action: AsyncThunkAction,
-  path: Path[],
-  value: unknown,
+  thunk: PluginAsyncThunk,
   item: QuestionnaireItem,
-  answer: QuestionnaireResponseItemAnswer,
-  multipleAnswers?: boolean
+  answer?: QuestionnaireResponseItemAnswer
 ) => void) => {
   const dispatch = useAppDispatch();
   const { globalOnChange } = useExternalRenderContext();
   const onAnswerChange = useOnAnswerChange(globalOnChange);
 
   return useCallback(
-    (
-      action: AsyncThunkAction,
-      path: Path[],
-      value: unknown,
-      item: QuestionnaireItem,
-      answer: QuestionnaireResponseItemAnswer,
-      multipleAnswers?: boolean
-    ): void => {
-      dispatch(action(path, value, item, multipleAnswers))?.then((newState: GlobalState) => onAnswerChange(newState, item, answer));
+    (thunk: PluginAsyncThunk, item: QuestionnaireItem, answer?: QuestionnaireResponseItemAnswer): void => {
+      dispatch(thunk)?.then((newState: GlobalState) => onAnswerChange(newState, item, answer));
     },
     [dispatch, onAnswerChange]
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export * from './reducers/index';
 export { default as rootReducer } from './reducers/index';
 //Hooks
 export { useIsEnabled, isEnableWhenEnabled, useCheckIfEnabled } from './hooks/useIsEnabled';
-export { usePluginDispatch } from './hooks/usePluginDispatch';
+export { usePluginDispatch, type PluginAsyncThunk } from './hooks/usePluginDispatch';
 export { usePluginValidation, type UsePluginValidationOptions, type UsePluginValidationResult } from './hooks/usePluginValidation';
 
 //Utils


### PR DESCRIPTION
… constants

BREAKING CHANGE: usePluginDispatch now takes a pre-built thunk instead of (action, path, value, item, answer, multipleAnswers?). Plugin authors call the action themselves and hand the result to pluginDispatch, which makes the hook work with every async action, including removeCodingStringValueAsync, toggleCodingValueAsync, addRepeatItemAsync, and the rest.

Also exports OPEN_CHOICE_ID and OPEN_CHOICE_SYSTEM so plugins can identify and build the "other" valueCoding.