### PR TITLE
Fix/plugin readonly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 24.0.1
+
+- Fix: Plugin component now receives `readOnly` and `pdf` props and renders its own readonly/pdf view. Previously the wrapper
+  short-circuited to `ReadOnly` before the item answer was resolved, so plugins never saw those props.
+
 ## 24.0.0
 
 - **Breaking**: `usePluginDispatch` now accepts a pre-built async thunk instead of `(action, path, value, item, answer, multipleAnswers?)`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helsenorge/refero",
-  "version": "23.4.0",
+  "version": "24.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helsenorge/refero",
-      "version": "23.4.0",
+      "version": "24.0.1",
       "license": "MIT",
       "dependencies": {
         "@helsenorge/core-utils": "^38.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "24.0.0",
+  "version": "24.0.1",
   "description": "Refero is a library that uses a fhir r4 schema and creates a interactive form using helsenorge packages.",
   "keywords": [
     "react",

--- a/src/components/formcomponents/plugin/PluginComponentWrapper.tsx
+++ b/src/components/formcomponents/plugin/PluginComponentWrapper.tsx
@@ -44,7 +44,7 @@ export const PluginComponentWrapper = (props: PluginComponentWrapperProps): Reac
   const item = useAppSelector(state => findQuestionnaireItem(state, linkId));
 
   // Get external render context - same pattern as Integer, Choice, etc.
-  const { promptLoginMessage, globalOnChange, resources } = useExternalRenderContext();
+  const { promptLoginMessage, globalOnChange, resources, validateScriptInjection } = useExternalRenderContext();
   const onAnswerChange = useOnAnswerChange(globalOnChange);
 
   // Get form context for error state (plugins register their own fields for validation)
@@ -80,6 +80,7 @@ export const PluginComponentWrapper = (props: PluginComponentWrapperProps): Reac
       index,
       promptLoginMessage,
       containedResources,
+      validateScriptInjection: !!validateScriptInjection,
     }),
     [
       item,
@@ -96,6 +97,7 @@ export const PluginComponentWrapper = (props: PluginComponentWrapperProps): Reac
       index,
       promptLoginMessage,
       containedResources,
+      validateScriptInjection,
     ]
   );
 

--- a/src/components/formcomponents/plugin/PluginComponentWrapper.tsx
+++ b/src/components/formcomponents/plugin/PluginComponentWrapper.tsx
@@ -6,7 +6,6 @@ import type { QuestionnaireComponentItemProps } from '@/components/createQuestio
 import type { PluginComponentProps } from '@/types/componentPlugin';
 
 import { PluginErrorBoundary } from './PluginErrorBoundary';
-import { ReadOnly } from '../read-only/readOnly';
 import RenderDeleteButton from '../repeat/RenderDeleteButton';
 import RenderRepeatButton from '../repeat/RenderRepeatButton';
 
@@ -103,23 +102,6 @@ export const PluginComponentWrapper = (props: PluginComponentWrapperProps): Reac
   // Guard: item must exist
   if (!item) {
     return null;
-  }
-
-  // PDF or ReadOnly mode - render simplified view
-  if (pdf || readOnly) {
-    return (
-      <ReadOnly
-        pdf={pdf}
-        id={id}
-        idWithLinkIdAndItemIndex={idWithLinkIdAndItemIndex}
-        item={item}
-        value={answer}
-        pdfValue={resources?.ikkeBesvart || ''}
-        errors={error}
-      >
-        {children}
-      </ReadOnly>
-    );
   }
 
   // Render delete/repeat buttons to pass as children to plugin

--- a/src/components/formcomponents/plugin/__tests__/PluginComponentWrapper-spec.tsx
+++ b/src/components/formcomponents/plugin/__tests__/PluginComponentWrapper-spec.tsx
@@ -117,27 +117,25 @@ describe('PluginComponentWrapper', () => {
   });
 
   describe('PDF mode', () => {
-    it('renders ReadOnly component when pdf is true', () => {
+    it('renders plugin with pdf prop set to true when pdf is true', () => {
       const pdfProps = { ...defaultProps, pdf: true };
       const { container } = renderWrapper(pdfProps);
 
-      // Should NOT render the plugin
-      expect(screen.queryByTestId('mock-plugin')).not.toBeInTheDocument();
-      // Should NOT have the plugin wrapper class
+      expect(screen.getByTestId('mock-plugin')).toBeInTheDocument();
+      expect(screen.getByTestId('plugin-pdf')).toHaveTextContent('true');
       // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-      expect(container.querySelector('.page_refero__component_plugin')).not.toBeInTheDocument();
+      expect(container.querySelector('.page_refero__component_plugin')).toBeInTheDocument();
     });
   });
 
   describe('ReadOnly mode', () => {
-    it('renders ReadOnly component when item is readOnly', () => {
+    it('renders plugin with readOnly prop set to true when item is readOnly', () => {
       const { container } = renderWrapper(defaultProps, readOnlyItem);
 
-      // Should NOT render the plugin
-      expect(screen.queryByTestId('mock-plugin')).not.toBeInTheDocument();
-      // Should NOT have the plugin wrapper class
+      expect(screen.getByTestId('mock-plugin')).toBeInTheDocument();
+      expect(screen.getByTestId('plugin-readonly')).toHaveTextContent('true');
       // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-      expect(container.querySelector('.page_refero__component_plugin')).not.toBeInTheDocument();
+      expect(container.querySelector('.page_refero__component_plugin')).toBeInTheDocument();
     });
   });
 

--- a/src/types/componentPlugin.ts
+++ b/src/types/componentPlugin.ts
@@ -84,6 +84,12 @@ export interface PluginComponentProps {
    * These are additional FHIR resources that are included within the item.
    */
   containedResources?: Resource[];
+
+  /**
+   * Whether to validate text inputs for script injection (XSS).
+   * Derived from the form consumer's configuration.
+   */
+  validateScriptInjection?: boolean;
 }
 
 /**


### PR DESCRIPTION
fix: let plugin component handle its own readOnly/pdf rendering

The wrapper short-circuited to <ReadOnly> when pdf or readOnly was true, so
plugins never received those props and the item answer was never resolved.
Pass readOnly/pdf through to the plugin and let it decide how to render.

Tests in PluginComponentWrapper-spec updated to assert the plugin is still
rendered and receives the pdf/readOnly props (instead of being replaced).
