### PR TITLE
Fix/plugin validation step view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 24.0.2
+
+- Fix: `usePluginValidation` no longer triggers premature validation when a plugin component mounts in step-view after a previous step has
+  been submitted. The hook now skips `shouldValidate` on the initial mount, preventing false error states on step navigation.
+
 ## 24.0.1
 
 - Fix: Plugin component now receives `readOnly` and `pdf` props and renders its own readonly/pdf view. Previously the wrapper

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helsenorge/refero",
-  "version": "24.0.1",
+  "version": "24.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helsenorge/refero",
-      "version": "24.0.1",
+      "version": "24.0.2",
       "license": "MIT",
       "dependencies": {
         "@helsenorge/core-utils": "^38.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helsenorge/refero",
-  "version": "24.0.1",
+  "version": "24.0.2",
   "description": "Refero is a library that uses a fhir r4 schema and creates a interactive form using helsenorge packages.",
   "keywords": [
     "react",

--- a/src/hooks/__tests__/usePluginValidation-spec.tsx
+++ b/src/hooks/__tests__/usePluginValidation-spec.tsx
@@ -321,4 +321,97 @@ describe('usePluginValidation', () => {
       expect(screen.getByTestId('has-error')).toHaveTextContent('yes');
     });
   });
+
+  it('does not validate on initial mount when isSubmitted is already true (step-view scenario)', async () => {
+    const store = createPluginTestStore(requiredItem);
+
+    // First render a field and submit to set isSubmitted = true
+    const { unmount } = render(
+      <TestPluginField
+        item={requiredItem}
+        idWithLinkIdAndItemIndex="step1-field-0"
+        value={42}
+        resources={defaultPluginTestResources as Resources}
+      />,
+      {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <PluginTestWrapper store={store} referoProps={{ resources: defaultPluginTestResources as Resources }}>
+            {children}
+          </PluginTestWrapper>
+        ),
+      }
+    );
+
+    // Submit the form — this sets formState.isSubmitted = true
+    fireEvent.click(screen.getByTestId('submit'));
+    await waitFor(() => {
+      expect(screen.getByTestId('has-error')).toHaveTextContent('no');
+    });
+
+    // Unmount first field (simulates navigating away from step 1)
+    unmount();
+
+    // Mount a new required field with no value (simulates step 2 mounting)
+    render(
+      <TestPluginField
+        item={requiredItem}
+        idWithLinkIdAndItemIndex="step2-field-0"
+        value={undefined}
+        resources={defaultPluginTestResources as Resources}
+      />,
+      {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <PluginTestWrapper store={store} referoProps={{ resources: defaultPluginTestResources as Resources }}>
+            {children}
+          </PluginTestWrapper>
+        ),
+      }
+    );
+
+    // The field should NOT show an error immediately on mount
+    await waitFor(() => {
+      expect(screen.getByTestId('has-error')).toHaveTextContent('no');
+    });
+  });
+
+  it('re-validates on value change after submission in step-view', async () => {
+    const store = createPluginTestStore(requiredItem);
+
+    // Render field, submit to set isSubmitted = true, then rerender with new value
+    const { rerender } = render(
+      <TestPluginField
+        item={requiredItem}
+        idWithLinkIdAndItemIndex="test-item-0"
+        value={42}
+        resources={defaultPluginTestResources as Resources}
+      />,
+      {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <PluginTestWrapper store={store} referoProps={{ resources: defaultPluginTestResources as Resources }}>
+            {children}
+          </PluginTestWrapper>
+        ),
+      }
+    );
+
+    // Submit — passes because value is 42
+    fireEvent.click(screen.getByTestId('submit'));
+    await waitFor(() => {
+      expect(screen.getByTestId('has-error')).toHaveTextContent('no');
+    });
+
+    // Change value to undefined — should trigger re-validation since isSubmitted and not initial mount
+    rerender(
+      <TestPluginField
+        item={requiredItem}
+        idWithLinkIdAndItemIndex="test-item-0"
+        value={undefined}
+        resources={defaultPluginTestResources as Resources}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('has-error')).toHaveTextContent('yes');
+    });
+  });
 });

--- a/src/hooks/usePluginValidation.ts
+++ b/src/hooks/usePluginValidation.ts
@@ -105,6 +105,10 @@ export const usePluginValidation = ({
   // Store the ref callback returned by register() so we can forward it to the plugin's element
   const registerRef = useRef<((el: HTMLElement | null) => void) | null>(null);
 
+  // Track whether the initial mount effect has run — prevents premature validation
+  // in step-view where isSubmitted is already true when a new step mounts.
+  const isInitialMount = useRef(true);
+
   // Register field with react-hook-form
   useEffect(() => {
     if (!shouldValidate(item, pdf)) return;
@@ -125,10 +129,16 @@ export const usePluginValidation = ({
     };
   }, [idWithLinkIdAndItemIndex, item, pdf, register, unregister, resources, rules]);
 
-  // Sync value into form state to trigger re-validation after submission
+  // Sync value into form state to trigger re-validation after submission.
+  // On initial mount we only set the value without validating — this prevents
+  // premature validation in step-view where isSubmitted is already true.
   useEffect(() => {
     if (shouldValidate(item, pdf)) {
-      setValue(idWithLinkIdAndItemIndex, value, { shouldValidate: formState.isSubmitted });
+      const shouldRevalidate = !isInitialMount.current && formState.isSubmitted;
+      setValue(idWithLinkIdAndItemIndex, value, { shouldValidate: shouldRevalidate });
+    }
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
     }
   }, [value, idWithLinkIdAndItemIndex, item, pdf, setValue, formState.isSubmitted]);
 


### PR DESCRIPTION
## Fix validation scroll/focus and step-view premature validation for plugin components

### Changes

**Validation scroll/focus (hn-skjemakomponenter)**
- Added `combinedRef` pattern to all 8 visual components so react-hook-form's validation summary can scroll to and focus the first input on error
- `refCallback` from `usePluginValidation` is called during React's commit phase before effects run, so the register ref isn't set yet — we store the element and replay via `useEffect`

**Step-view premature validation (refero — 24.0.2)**
- Fixed `usePluginValidation` triggering validation immediately when a plugin mounts in step-view after a previous step submission
- Added `isInitialMount` ref to skip `shouldValidate` on first render
